### PR TITLE
refactor(lesson-8): remove AppHeader duplication from SimpleLayout & add Vercel rewrites

### DIFF
--- a/hw-lesson-8/client/src/layout/SimpleLayout.jsx
+++ b/hw-lesson-8/client/src/layout/SimpleLayout.jsx
@@ -1,18 +1,14 @@
 import AppButton from '@/shared/ui/AppButton'
-import AppHeader from '@/shared/ui/AppHeader'
 import { Outlet, useNavigate } from 'react-router-dom'
 export default function PageLayout() {
   const navigate = useNavigate()
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-50">
-      <AppHeader />
-      <div className="pt-24 px-4 pb-10">
-        <div className="mx-auto max-w-3xl bg-white/90 backdrop-blur rounded-xl shadow-sm ring-1 ring-green-100 p-6">
-          <div className="flex justify-end mb-6">
-            <AppButton variant="outline" onClick={() => navigate(-1)}>Назад</AppButton>
-          </div>
-          <Outlet />
+    <div className="min-h-screen bg-gradient-to-br from-green-50 via-white to-green-50 pt-10 px-4 pb-10">
+      <div className="mx-auto max-w-3xl bg-white/90 backdrop-blur rounded-xl shadow-sm ring-1 ring-green-100 p-6">
+        <div className="flex justify-end mb-6">
+          <AppButton variant="outline" onClick={() => navigate(-1)}>Назад</AppButton>
         </div>
+        <Outlet />
       </div>
     </div>
   )

--- a/hw-lesson-8/client/vercel.json
+++ b/hw-lesson-8/client/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
Removed duplicate <AppHeader /> from SimpleLayout to simplify layout structure and avoid redundancy.

Adjusted padding (pt-10) to maintain consistent spacing after header removal.

Added vercel.json with rewrites config to ensure proper client-side routing on Vercel.