### PR TITLE
fix(lesson-8): replace '*' catch-all with '/*' for Express 5

### DIFF
--- a/hw-lesson-8/server/src/index.js
+++ b/hw-lesson-8/server/src/index.js
@@ -11,7 +11,9 @@ app.use(cors({ origin: config.clientUrl, credentials: true }))
 app.use(express.json())
 app.use('/api/v1/teachers', teacherRoutes)
 app.use('/api/v1/meetings', meetingRoutes)
-app.use('*', notFound)
+// Express 5 + path-to-regexp v6: '*' shorthand can throw (Missing parameter name)
+// Use a safe catch-all pattern
+app.all('/*', notFound)
 app.use(errorHandler)
 app.listen(config.port, () => {
   console.log(`🚀 Server running at http://localhost:${config.port}`)


### PR DESCRIPTION
fix(lesson-8): replace '*' catch-all with '/*' for Express 5"